### PR TITLE
fix "program" macro issue

### DIFF
--- a/programs/token-extension/src/lib.rs
+++ b/programs/token-extension/src/lib.rs
@@ -1,9 +1,10 @@
 pub mod instructions;
 pub mod state;
-use crate::instructions::{ChallengeParams, CreateChallenge};
-use crate::state::{ChallengeMetadata, EscrowAccount};
+// use crate::instructions::{ChallengeParams, CreateChallenge};
+use crate::state::ChallengeMetadata;
 use anchor_lang::prelude::*;
 use anchor_spl::token::{self, Transfer};
+use anchor_spl::token::{Mint, TokenAccount};
 
 declare_id!("FUkgpVESK463wEYuwfpTbXGr2YtgezdQnSDPhteNWyrN");
 
@@ -52,6 +53,29 @@ pub mod p2p_challenge {
         token::transfer(cpi_ctx, params.stake_amount)?;
 
         Ok(())
+    }
+
+    #[derive(Clone, AnchorSerialize, AnchorDeserialize)]
+    pub struct ChallengeParams {
+        pub goal: u64,
+        pub challenge_type: u8,
+        pub start_time: i64,
+        pub end_time: i64,
+        pub stake_amount: u64,
+    }
+
+    #[derive(Accounts)]
+    pub struct CreateChallenge<'info> {
+        #[account(init, payer = creator, space = ChallengeMetadata::LEN)]
+        pub challenge_metadata: Account<'info, ChallengeMetadata>,
+        #[account(mut)]
+        pub escrow_token_account: Account<'info, TokenAccount>,
+        pub token_mint: Account<'info, Mint>,
+        #[account(mut)]
+        pub creator: Signer<'info>,
+        pub system_program: Program<'info, System>,
+        pub token_program: AccountInfo<'info>,
+        pub rent: Sysvar<'info, Rent>,
     }
 }
 


### PR DESCRIPTION
The Account struct should be within the mod with the #program macro assigned to it. So, I have moved both the Account structs within p2p_challenge.

The instruction.rs is pretty useless now (but we will find a. But we need to find another way to split the code if we want to.